### PR TITLE
Add time-adjust to new blocks to avoid block length less than 15 seconds

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -65,6 +65,13 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
 
+    // avoid short-time difficulty spike in Kimoto Gravity Well
+    // but only for blocks that fall between beginning of Kimoto and beginning of Dark Gravity
+    if (pindexPrev->nHeight + 1 >= consensusParams.nPowKGWHeight &&
+            pindexPrev->nHeight + 1 < consensusParams.nPowDGWHeight) {
+        nNewTime = std::max(nNewTime, pindexPrev->GetBlockTime()+15);  // pad at least 15 seconds to prev block
+    }
+
     if (nOldTime < nNewTime)
         pblock->nTime = nNewTime;
 


### PR DESCRIPTION
This adds code to time-adjust new blocks to be at least 15 seconds after the last block, but only during the period where Kimoto Gravity Well is active.

If the block time is already more than 15 seconds ahead of the previous block, no change is made.