### PR TITLE
Add 'masternodelist qualified' output. Like 'full' list but prunes nodes

### DIFF
--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -102,7 +102,7 @@ public:
             READWRITE(strVersion);
         }
         else {
-            strVersion = SERIALIZATION_VERSION_STRING; 
+            strVersion = SERIALIZATION_VERSION_STRING;
             READWRITE(strVersion);
         }
 
@@ -170,6 +170,8 @@ public:
     bool GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCountRet, masternode_info_t& mnInfoRet);
     /// Same as above but use current block height
     bool GetNextMasternodeInQueueForPayment(bool fFilterSigTime, int& nCountRet, masternode_info_t& mnInfoRet);
+    /// Get the qualified current masternodes (eligible for payment)
+    int GetQualifiedMasternodesInQueueForPayment(std::vector<std::pair<int, CMasternode*> >& vecMasternodePosRet, bool fFilterSigTime);
 
     /// Find a random entry
     masternode_info_t FindRandomNotInVec(const std::vector<COutPoint> &vecToExclude, int nProtocolVersion = -1);


### PR DESCRIPTION
Prunes nodes not qualified for payment, and sorted by last-paid, giving reasonable ability to predict time-to-pay masternodes.

This command can be useful for reporting masternode status, determining if a masternode has past the initial time-period to be considered qualified for payment.

The nodes are listed in expected order of payment (though of course actual winners are chosen randomly* from the top 10% of nodes).